### PR TITLE
Tagging articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -39,7 +39,7 @@ class ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :body)
+    params.require(:article).permit(:title, :body, :tag_list)
   end
 
   def set_article

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,12 @@
 class CommentsController < ApplicationController
   def create
-    # Where does article_id param come from????
+    # Q: Where does article_id param come from????
+
+    # A: Forms with models will default to using the restful routes. 
+    # When you have two models, it creates nested routes, 
+    # in this case /articles/:article_id/comments . 
+    # So the param is actually being passed through a dynamic segment in the route
+    
     @comment = Comment.new(comment_params)
     @comment.article_id = params[:article_id]
   

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,4 +3,8 @@ class Article < ApplicationRecord
   has_many :comments
   has_many :taggings
   has_many :tags, through: :taggings
+
+  def tag_list
+    tags.join(", ")
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,4 +7,13 @@ class Article < ApplicationRecord
   def tag_list
     tags.join(", ")
   end
+
+  def tag_list=(tags_string)
+    tag_names = tags_string.split(",").collect{|s| s.strip.downcase}.uniq
+    # go through each of those tag_names and find or create a tag with that name. Rails has a built in method to do just that, like this:
+    new_or_found_tags = tag_names.collect { |name| Tag.find_or_create_by(name: name) }
+    # collect up these new or found new tags and then assign them to our article.
+    self.tags = new_or_found_tags
+  end
+
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,10 @@
 class Tag < ApplicationRecord
   has_many :taggings
   has_many :articles, through: :taggings
+
+  # The tag_list method in article model uses join, which by default uses .to_s applied to every element in the array
+  # we can override to_s to output the name for each element
+  def to_s
+    name
+  end
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -13,6 +13,10 @@
     <%= f.text_area :body %>
   </p>
   <p>
+    <%= f.label :tag_list %><br />
+    <%= f.text_field :tag_list %>
+  </p>
+  <p>
     <%= f.submit %>
   </p>
 <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,6 +1,16 @@
 <h1><%= @article.title %></h1>
+
+<p>
+  Tags:
+  <% @article.tags.each do |tag| %>
+    <%= tag.name %>
+  <% end %>
+</p>
+
 <p><%= @article.body %></p>
+
 <%= link_to "Delete", article_path(@article), method: :delete, data: {confirm: "Really delete the article?"} %>
+
 <%= link_to "edit", edit_article_path(@article) %>
 
 <h3>Comments: (<%= @article.comments.size %>)</h3>

--- a/spec/features/articles/user_creates_a_new_article_spec.rb
+++ b/spec/features/articles/user_creates_a_new_article_spec.rb
@@ -13,9 +13,10 @@ describe "user creates a new article" do
         fill_in "article[body]",  with: "New Body!"
         fill_in "article[tag_list]", with: "ruby, technology"
         click_on "Create Article"
-
+        
         expect(page).to have_content("New Title!")
         expect(page).to have_content("New Body!")
+        expect(page).to have_content("ruby technology")
       end
     end
   end

--- a/spec/features/articles/user_creates_a_new_article_spec.rb
+++ b/spec/features/articles/user_creates_a_new_article_spec.rb
@@ -11,6 +11,7 @@ describe "user creates a new article" do
 
         fill_in "article[title]", with: "New Title!"
         fill_in "article[body]",  with: "New Body!"
+        fill_in "article[tag_list]", with: "ruby, technology"
         click_on "Create Article"
 
         expect(page).to have_content("New Title!")

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe Article, type: :model do
   end
 
   describe 'instance methods' do
+    describe "#tag_list" do
+      it "turns associated tags into a string" do
+        article = Article.create(title: "Tall Tables", body: "They are tough for the short legged")
+        article.tags.create(name: "furniture")
+        article.tags.create(name: "opinions")
+
+        expect(article.tag_list).to eq("furniture, opinions")
+      end
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Tag, type: :model do
   end
 
   describe 'instance methods' do
+    it '#to_s' do
+      article = Article.create(title: "Tall Tables", body: "They are tough for the short legged")
+      article.tags.create(name: "furniture")
+      article.tags.create(name: "opinions")
+
+      expect(Tag.first.to_s).to eq("furniture")
+    end
   end
 
   describe 'class methods' do


### PR DESCRIPTION
## Purpose
Adds tags form on article creation
Adds `tag_list` & `tag_list=` article instance methods to display tags for each article
Adds `to_s` override in tag model (involked during `tag_list` `.join(", ")`
Adds model test cases for `tag_list` and `to_s` override 
Adds feature test for tags on article new page
All tests passing